### PR TITLE
fix search toolbar improper space occupation

### DIFF
--- a/app/webpacker/stylesheets/_search.scss
+++ b/app/webpacker/stylesheets/_search.scss
@@ -1,9 +1,5 @@
 .appbar {
-  .search-open-button {
-    display: none;
-  }
-
-  .search-close-button {
+  .search-toolbar-action-toggle {
     display: none;
   }
 }


### PR DESCRIPTION
原来的 search toolbar 在大屏的时候会占一个 12x12 的空间，因为 `toolbar-action` 有 `padding: 6px` （红框是用来辅助观察的，没有 commit）

![image](https://user-images.githubusercontent.com/15063844/63099278-594a5c80-bfa7-11e9-804c-f9a01018bede.png)

把原本加在按钮上的 `display:none` 转移到父元素 `search-toolbar-action-toggle` 上就可以了

![image](https://user-images.githubusercontent.com/15063844/63099581-f4433680-bfa7-11e9-9814-7190300932eb.png)