### PR TITLE
fix reaction cannot be deleted on initialize

### DIFF
--- a/app/webpacker/javascripts/controllers/topic_controller.js
+++ b/app/webpacker/javascripts/controllers/topic_controller.js
@@ -225,6 +225,7 @@ export default class extends Controller {
     if (ids && ids.length) {
       ids.split(',').forEach((id) => {
         document.querySelector(`#post-${id}-reaction-${type}`).classList.add('active')
+        document.querySelector(`#post-${id}-reaction-${type}`).dataset.method = 'delete'
       })
     }
   }


### PR DESCRIPTION
`reactions/_reaction.html.erb` 局部视图中，点击按钮后在 `create.js.erb` 中有：
```javascript
button.dataset.method = 'delete';
```
从而再次点击可以取消（删除 reaction），但是在刷新页面的时候没有这个逻辑，只有把按钮置成点亮的动作（class 设置成 active），所以更新了 `topic_controller.js` 的 `parseReaction` 方法