### PR TITLE
Fix users validate

### DIFF
--- a/app/views/topics/_topic.html.erb
+++ b/app/views/topics/_topic.html.erb
@@ -1,5 +1,5 @@
 <% cache [I18n.locale, topic] do %>
-<a class="list-item" href="<%= topic_path(topic) %>">
+  <a class="list-item" href="<%= topic_path(topic) %>">
     <div class="list-item-avatar">
       <img src="<%= topic.user.avatar.thumb.url %>" class="avatar">
     </div>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -1,5 +1,5 @@
 <%= form_with model: @user, class: 'form', id: 'sign-up-form', data: { controller: 'form-validation' } do |form| %>
-  <div class="form-field">
+  <div class="form-field <%= 'invalid' if @user.errors[:name].any? %>">
     <%= form.label :name %>
     <%= form.text_field :name, 'data-validate-url': '/users/validate/name' %>
     <% if @user.errors[:name].any? %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -37,6 +37,14 @@ en:
       post: Post
       topic: Topic
       user: User
+    errors:
+      models:
+        user:
+          attributes:
+            username:
+              invalid: Only accept English letters
+            email:
+              invalid: Not valid email address
   admin:
     attachments:
       index:

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -37,6 +37,14 @@ zh-CN:
       post: 帖子
       topic: 主题
       user: 用户
+    errors:
+      models:
+        user:
+          attributes:
+            username:
+              invalid: 只接受英文字母
+            email:
+              invalid: 不符合邮箱格式
   admin:
     attachments:
       index:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,8 +5,11 @@ Rails.application.routes.draw do
   root to: 'home#index'
 
   resources :users, only: [:create] do
-    post 'validate/:attribute', to: 'users#validate', constraints: { attribute: /name|username|email|password/ }
+    collection do
+      post 'validate/:attribute', to: 'users#validate', constraints: { attribute: /name|username|email|password/ }
+    end
   end
+
   resource :password_reset, only: [:show, :create, :edit, :update]
   resource :session, only: [:create]
   get '/sign_up', to: 'users#new', as: :sign_up


### PR DESCRIPTION
`users/_form` 中的 validate url 是：`'data-validate-url': '/users/validate/name'`

而 `users#validate` 的 route 因为用了 resources 所以多了个 `:user_id`:

```
resources :users, only: [:create] do
  post 'validate/:attribute', to: 'users#validate', constraints: { attribute: /name|username|email|password/ }
end

=>

POST   /users/:user_id/validate/:attribute(.:format)   users#validate {:attribute=>/name|username|email|password/}
```

修改：保持一致性，我用了和 `forums#validate` 一样的写法，用 collection 把它包起来。

另外，缺失 `invalid` 的错误信息翻译，可以直接加到 `errors/messages` 与 `blank` 同级，但是考虑到用户名的 `invalid` 最好根据自定义的正则有所提示，所以和邮箱的 `invalid` 一起加到了 `activerecord/errors` 底下（翻译不好还请修正）。