### PR TITLE
add manually expire user pwd reset token

### DIFF
--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -23,6 +23,7 @@ class PasswordResetsController < ApplicationController
 
   def update
     if @user.update params.require(:user).permit(:password, :password_confirmation)
+      User.verifier = Rails.application.message_verifier('User-' + SecureRandom.base64(8))
       redirect_to sign_in_path, notice: t('flash.password_is_successfully_reset')
     else
       render 'update_form'

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -29,9 +29,10 @@ class User < ApplicationRecord
   validates :email, format: { with: URI::MailTo::EMAIL_REGEXP }
 
   mattr_accessor :verifier
-  self.verifier = Rails.application.message_verifier('User')
+  self.verifier = Rails.application.message_verifier('User-default')
 
   def password_reset_token
+    self.class.verifier = Rails.application.message_verifier('User-' + SecureRandom.base64(8))
     self.class.verifier.generate(id, purpose: :password_reset, expires_in: 5.minutes)
   end
 


### PR DESCRIPTION
考虑在重新发送重置密码邮件（regenerate token）和成功重置密码（update）之后主动将之前生成的 token 失效，用来避免可能的用户误导以及增加一定安全性。

@chloerei 你看有没有必要？